### PR TITLE
Re-enable loading libffi from system.

### DIFF
--- a/lib/internal/libffi_library/src/libffi_library.dart
+++ b/lib/internal/libffi_library/src/libffi_library.dart
@@ -71,7 +71,7 @@ class LibffiLibrary {
 
     var handle = _loadFromLibffiBinaries(filename);
     if (handle == 0) {
-      //handle = Unsafe.libraryLoad(filename);
+      handle = Unsafe.libraryLoad(filename);
     }
 
     if (handle == 0) {


### PR DESCRIPTION
I have re-enabled loading libffi from the system if it exists. I didn't check to see why it was commented out, so if you could tell me why, that would be great :)
